### PR TITLE
PRO-2886: Updated build.gradle to use spring boot version 1.5.13.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 plugins {
     id 'application'
     id 'pmd'
-    id 'org.springframework.boot' version '1.5.8.RELEASE'
+    id 'org.springframework.boot' version '1.5.13.RELEASE'
     id 'org.owasp.dependencycheck' version '3.1.2'
     id 'com.github.ben-manes.versions' version '0.15.0'
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2886

### Change description ###
Updated spring boot framework from 1.5.8 to 1.5.13 to eliminate the security vulnerabilities.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
