### PR TITLE
PRO-3028: Updated Business service to include persistence health check.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.retry', name: 'spring-retry'
     compile group: 'org.hibernate', name: 'hibernate-validator'
+    compile group: 'org.projectlombok', name: 'lombok', version: '1.16.18'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.8.0-RELEASE'
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.logging
@@ -167,7 +168,7 @@ dependencies {
     testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-core', version: '1.5.2'
     testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: '1.5.2'
     testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: '1.5.2'
-    testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'
+    testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'    
     testFunctionalCompile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
     testFunctionalCompile sourceSets.main.runtimeClasspath
     testFunctionalCompile sourceSets.test.runtimeClasspath

--- a/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.probate.services.business.health;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BusinessHealthConfiguration
+{	
+    @Autowired
+    private RestTemplate restTemplate;
+    
+    @Value("${services.persistence.baseUrl}")    
+    private String servicePersistenceBaseUrl;
+    
+    @Bean
+    public BusinessHealthIndicator persistenceServiceHealthIndicator() {
+    	return new BusinessHealthIndicator(servicePersistenceBaseUrl, restTemplate); 
+    }    
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.probate.services.business.health;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor
+public class BusinessHealthIndicator implements HealthIndicator {
+	
+	private final static String EXCEPTION_KEY = "exception";
+	private final static String MESSAGE_KEY = "message";
+    private final static String URL_KEY = "url";
+
+    private final String url;
+    private RestTemplate restTemplate;
+    
+    @Override
+    public Health health() {
+    	ResponseEntity<String> responseEntity;
+
+        try {
+            responseEntity = restTemplate.getForEntity(url + "/health", String.class);
+
+        } catch (ResourceAccessException rae) {
+            log.error(rae.getMessage(), rae);
+            return getHealthWithDownStatus(url, rae.getMessage(), "ResourceAccessException");
+        } catch (HttpStatusCodeException hsce) {
+            log.error(hsce.getMessage(), hsce);
+            return getHealthWithDownStatus(url, hsce.getMessage(),
+                    "HttpStatusCodeException - HTTP Status: " + hsce.getStatusCode().value());
+        } catch (UnknownHttpStatusCodeException uhsce) {
+            log.error(uhsce.getMessage(), uhsce);
+            return getHealthWithDownStatus(url, uhsce.getMessage(), "UnknownHttpStatusCodeException - " + uhsce.getStatusText());
+        }
+
+        if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
+        	System.out.println("stage BAD");
+            return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
+        }
+
+        return getHealthWithUpStatus(url);
+
+    }
+
+    private Health getHealthWithUpStatus(String url) {
+        return Health.up()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, "HTTP Status OK")
+                .build();
+    }
+
+    private Health getHealthWithDownStatus(String url, String message, String status) {
+        return Health.down()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, message)
+                .withDetail(EXCEPTION_KEY, status)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
@@ -16,9 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class BusinessHealthIndicator implements HealthIndicator {
 	
-	private final static String EXCEPTION_KEY = "exception";
-	private final static String MESSAGE_KEY = "message";
-    private final static String URL_KEY = "url";
+	private final static String ERROR_KEY = "error";
 
     private final String url;
     private RestTemplate restTemplate;
@@ -28,41 +26,35 @@ public class BusinessHealthIndicator implements HealthIndicator {
     	ResponseEntity<String> responseEntity;
 
         try {
+        	log.debug("Attempting to access health endpoint: " + url + "/health");
             responseEntity = restTemplate.getForEntity(url + "/health", String.class);
-
         } catch (ResourceAccessException rae) {
             log.error(rae.getMessage(), rae);
-            return getHealthWithDownStatus(url, rae.getMessage(), "ResourceAccessException");
+            return getHealthWithDownStatus("Connection failed with ResourceAccessException");
         } catch (HttpStatusCodeException hsce) {
             log.error(hsce.getMessage(), hsce);
-            return getHealthWithDownStatus(url, hsce.getMessage(),
-                    "HttpStatusCodeException - HTTP Status: " + hsce.getStatusCode().value());
+            return getHealthWithDownStatus("HTTP Status: " + hsce.getStatusCode().value());
         } catch (UnknownHttpStatusCodeException uhsce) {
             log.error(uhsce.getMessage(), uhsce);
-            return getHealthWithDownStatus(url, uhsce.getMessage(), "UnknownHttpStatusCodeException - " + uhsce.getStatusText());
+            return getHealthWithDownStatus("Connection failed with UnknownHttpStatusCodeException");
         }
 
         if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
-        	System.out.println("stage BAD");
-            return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
+            return getHealthWithDownStatus("HTTP Status: " + responseEntity.getStatusCodeValue());
         }
 
-        return getHealthWithUpStatus(url);
+        return getHealthWithUpStatus();
 
     }
 
-    private Health getHealthWithUpStatus(String url) {
+    private Health getHealthWithUpStatus() {
         return Health.up()
-                .withDetail(URL_KEY, url)
-                .withDetail(MESSAGE_KEY, "HTTP Status OK")
                 .build();
     }
 
-    private Health getHealthWithDownStatus(String url, String message, String status) {
+    private Health getHealthWithDownStatus(String error) {
         return Health.down()
-                .withDetail(URL_KEY, url)
-                .withDetail(MESSAGE_KEY, message)
-                .withDetail(EXCEPTION_KEY, status)
+                .withDetail(ERROR_KEY, error)
                 .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
@@ -16,7 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class BusinessHealthIndicator implements HealthIndicator {
 	
-	private final static String ERROR_KEY = "error";
+	private final static String EXCEPTION_KEY = "exception";
+	private final static String MESSAGE_KEY = "message";
+    private final static String URL_KEY = "url";
 
     private final String url;
     private RestTemplate restTemplate;
@@ -26,35 +28,41 @@ public class BusinessHealthIndicator implements HealthIndicator {
     	ResponseEntity<String> responseEntity;
 
         try {
-        	log.debug("Attempting to access health endpoint: " + url + "/health");
             responseEntity = restTemplate.getForEntity(url + "/health", String.class);
+
         } catch (ResourceAccessException rae) {
             log.error(rae.getMessage(), rae);
-            return getHealthWithDownStatus("Connection failed with ResourceAccessException");
+            return getHealthWithDownStatus(url, rae.getMessage(), "ResourceAccessException");
         } catch (HttpStatusCodeException hsce) {
             log.error(hsce.getMessage(), hsce);
-            return getHealthWithDownStatus("HTTP Status: " + hsce.getStatusCode().value());
+            return getHealthWithDownStatus(url, hsce.getMessage(),
+                    "HttpStatusCodeException - HTTP Status: " + hsce.getStatusCode().value());
         } catch (UnknownHttpStatusCodeException uhsce) {
             log.error(uhsce.getMessage(), uhsce);
-            return getHealthWithDownStatus("Connection failed with UnknownHttpStatusCodeException");
+            return getHealthWithDownStatus(url, uhsce.getMessage(), "UnknownHttpStatusCodeException - " + uhsce.getStatusText());
         }
 
         if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
-            return getHealthWithDownStatus("HTTP Status: " + responseEntity.getStatusCodeValue());
+        	System.out.println("stage BAD");
+            return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
         }
 
-        return getHealthWithUpStatus();
+        return getHealthWithUpStatus(url);
 
     }
 
-    private Health getHealthWithUpStatus() {
+    private Health getHealthWithUpStatus(String url) {
         return Health.up()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, "HTTP Status OK")
                 .build();
     }
 
-    private Health getHealthWithDownStatus(String error) {
+    private Health getHealthWithDownStatus(String url, String message, String status) {
         return Health.down()
-                .withDetail(ERROR_KEY, error)
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, message)
+                .withDetail(EXCEPTION_KEY, status)
                 .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicator.java
@@ -43,7 +43,6 @@ public class BusinessHealthIndicator implements HealthIndicator {
         }
 
         if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
-        	System.out.println("stage BAD");
             return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,15 @@
 ---
+  security:
+    basic:
+      enabled: false
+
+  management:
+    security:
+      enabled: false
+
   server:
     port: 8080
-    
+          
   spring:
     application:
       name: probate-business-service
@@ -18,10 +26,11 @@
 
   services:
     persistence:
+      baseUrl: http://localhost:8282
       invitedata:
-        url: "http://localhost:8282/invitedata"
+        url: ${services.persistence.baseUrl}/invitedata
       formdata:
-        url: "http://localhost:8282/formdata"
+        url: ${services.persistence.baseUrl}/formdata
     notify:
       apiKey: "dummykey"
       invitedata:

--- a/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
@@ -18,6 +18,8 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.UnknownHttpStatusCodeException;
 
+import uk.gov.hmcts.probate.services.business.health.BusinessHealthIndicator;
+
 @RunWith(MockitoJUnitRunner.class)
 public class BusinessHealthIndicatorTest {
 
@@ -29,20 +31,21 @@ public class BusinessHealthIndicatorTest {
     @Mock
     private ResponseEntity<String> mockResponseEntity;
     
-    private BusinessHealthIndicator businesstHealthIndicator;
+    private BusinessHealthIndicator businessHealthIndicator;
     
     @Before
     public void setUp() {
-    	businesstHealthIndicator = new BusinessHealthIndicator(URL, mockRestTemplate);
+    	businessHealthIndicator = new BusinessHealthIndicator(URL, mockRestTemplate);
     }
 
 	@Test
     public void shouldReturnStatusOfUpWhenHttpStatusIsOK() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);      
         when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
-        Health health = businesstHealthIndicator.health();
+        Health health = businessHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.UP));
+        assertThat(health.getDetails().get("url"), is(URL));
     }
 
 	@Test
@@ -50,29 +53,37 @@ public class BusinessHealthIndicatorTest {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);
         when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.NO_CONTENT);
         when(mockResponseEntity.getStatusCodeValue()).thenReturn(HttpStatus.NO_CONTENT.value());
-        Health health = businesstHealthIndicator.health();
+        Health health = businessHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("HTTP Status: 204"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
+        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
         final String message = "EXCEPTION MESSAGE";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
-        Health health = businesstHealthIndicator.health();
-        
+
+        Health health = businessHealthIndicator.health();
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("Connection failed with ResourceAccessException"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is(message));
+        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-        Health health = businesstHealthIndicator.health();
-        
+
+        Health health = businessHealthIndicator.health();
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("HTTP Status: 400"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
+        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
     }
 
     @Test
@@ -80,9 +91,12 @@ public class BusinessHealthIndicatorTest {
         final String statusText = "status text";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class))
                 .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
-        Health health = businesstHealthIndicator.health();
-        
+
+        Health health = businessHealthIndicator.health();
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("Connection failed with UnknownHttpStatusCodeException"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
+        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.probate.services.business.health;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+import uk.gov.hmcts.probate.services.business.health.BusinessHealthIndicator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BusinessHealthIndicatorTest {
+
+    private static final String URL = "http://url.com";
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+   
+    @Mock
+    private ResponseEntity<String> mockResponseEntity;
+    
+    private BusinessHealthIndicator businessHealthIndicator;
+    
+    @Before
+    public void setUp() {
+    	businessHealthIndicator = new BusinessHealthIndicator(URL, mockRestTemplate);
+    }
+
+	@Test
+    public void shouldReturnStatusOfUpWhenHttpStatusIsOK() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);      
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+        Health health = businessHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.UP));
+        assertThat(health.getDetails().get("url"), is(URL));
+    }
+
+	@Test
+    public void shouldReturnStatusOfDownWhenHttpStatusIsNotOK() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.NO_CONTENT);
+        when(mockResponseEntity.getStatusCodeValue()).thenReturn(HttpStatus.NO_CONTENT.value());
+        Health health = businessHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
+        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
+        final String message = "EXCEPTION MESSAGE";
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
+
+        Health health = businessHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is(message));
+        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        Health health = businessHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
+        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenUnknownHttpStatusCodeExceptionIsThrown() {
+        final String statusText = "status text";
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class))
+                .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
+
+        Health health = businessHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
+        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/business/health/BusinessHealthIndicatorTest.java
@@ -18,8 +18,6 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.UnknownHttpStatusCodeException;
 
-import uk.gov.hmcts.probate.services.business.health.BusinessHealthIndicator;
-
 @RunWith(MockitoJUnitRunner.class)
 public class BusinessHealthIndicatorTest {
 
@@ -31,21 +29,20 @@ public class BusinessHealthIndicatorTest {
     @Mock
     private ResponseEntity<String> mockResponseEntity;
     
-    private BusinessHealthIndicator businessHealthIndicator;
+    private BusinessHealthIndicator businesstHealthIndicator;
     
     @Before
     public void setUp() {
-    	businessHealthIndicator = new BusinessHealthIndicator(URL, mockRestTemplate);
+    	businesstHealthIndicator = new BusinessHealthIndicator(URL, mockRestTemplate);
     }
 
 	@Test
     public void shouldReturnStatusOfUpWhenHttpStatusIsOK() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);      
         when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
-        Health health = businessHealthIndicator.health();
+        Health health = businesstHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.UP));
-        assertThat(health.getDetails().get("url"), is(URL));
     }
 
 	@Test
@@ -53,37 +50,29 @@ public class BusinessHealthIndicatorTest {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);
         when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.NO_CONTENT);
         when(mockResponseEntity.getStatusCodeValue()).thenReturn(HttpStatus.NO_CONTENT.value());
-        Health health = businessHealthIndicator.health();
+        Health health = businesstHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
-        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
+        assertThat(health.getDetails().get("error"), is("HTTP Status: 204"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
         final String message = "EXCEPTION MESSAGE";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
-
-        Health health = businessHealthIndicator.health();
-
+        Health health = businesstHealthIndicator.health();
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is(message));
-        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
+        assertThat(health.getDetails().get("error"), is("Connection failed with ResourceAccessException"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-
-        Health health = businessHealthIndicator.health();
-
+        Health health = businesstHealthIndicator.health();
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
-        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
+        assertThat(health.getDetails().get("error"), is("HTTP Status: 400"));
     }
 
     @Test
@@ -91,12 +80,9 @@ public class BusinessHealthIndicatorTest {
         final String statusText = "status text";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class))
                 .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
-
-        Health health = businessHealthIndicator.health();
-
+        Health health = businesstHealthIndicator.health();
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
-        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
+        assertThat(health.getDetails().get("error"), is("Connection failed with UnknownHttpStatusCodeException"));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,12 @@
 ---
+  security:
+    basic:
+      enabled: false
+
+  management:
+    security:
+      enabled: false
+      
   server:
     port: 8080
     
@@ -18,10 +26,11 @@
 
   services:
     persistence:
+      baseUrl: http://localhost:8282
       invitedata:
-        url: "http://localhost:8282/invitedata"
+        url: ${services.persistence.baseUrl}/invitedata
       formdata:
-        url: "http://localhost:8282/formdata"
+        url: ${services.persistence.baseUrl}/formdata
     notify:
       apiKey: "probate_test_key-fce47f9c-7bbe-4f41-829e-5144a3820768-4b461773-72e0-465e-868a-91482cfc8aa4"
       invitedata:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3028

### Change description ###
Updated the health endpoint for Business service with a Persistence URL check. Spring Actuator also includes a diskSpace check as well.

Example JSON being returned: 
{"status":"UP","persistenceService":{"status":"UP"},"diskSpace":{"status":"UP","total":499963170816,"free":422908248064,"threshold":10485760}}

If an error occurs you get:
{"status":"DOWN","persistenceService":{"status":"DOWN","error":"Connection failed with ResourceAccessException"},"diskSpace":{"status":"UP","total":499963170816,"free":422908416000,"threshold":10485760}}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
