### PR TITLE
PRO-3028: Removed duplicate gitproperties in build.gradle after a mer…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,7 @@ apply plugin: 'net.serenity-bdd.aggregator'
 
 
 gitProperties {
-	gitPropertiesDir = new File("${project.rootDir}/src/main/resources/uk/gov/hmcts/probate/services/business")
-    keys = ['git.commit.id','git.commit.time']
-    dateFormat = "yyyy-MM-dd'T'HH:mmZ"
-    dateFormatTimeZone = "GMT"
-}
-
-gitProperties {
-	gitPropertiesDir = new File("${project.rootDir}/src/main/resources/uk/gov/hmcts/probate/services/business")
+    gitPropertiesDir = new File("${project.rootDir}/src/main/resources/uk/gov/hmcts/probate/services/business")
     keys = ['git.commit.id','git.commit.time']
     dateFormat = "yyyy-MM-dd'T'HH:mmZ"
     dateFormatTimeZone = "GMT"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3028


### Change description ###
Minor update to remove **duplicated** gitProperties configuration in build.gradle after a merge conflict issue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
