### PR TITLE
Pro 3459 pin not working for international numbers

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
@@ -27,16 +27,17 @@ public class BusinessServicePinControllerTests extends IntegrationTestBase {
     }
 
     private void validatePinSuccess(String phoneNumber) {
+    	
         SerenityRest.given().relaxedHTTPSValidation()
                 .headers(utils.getHeaders(SESSION_ID))
-                .when().get(businessServiceUrl + "/pin/" + phoneNumber)
+                .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
                 .then().assertThat().statusCode(200);
     }
 
     private void validatePinFailure(String phoneNumber) {
         Response response = SerenityRest.given().relaxedHTTPSValidation()
                 .headers(utils.getHeaders(SESSION_ID))
-                .when().get(businessServiceUrl + "/pin/" + phoneNumber)
+                .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
                 .thenReturn();
 
         response.then().assertThat().statusCode(500)

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
@@ -26,8 +26,7 @@ public class BusinessServicePinControllerTests extends IntegrationTestBase {
         validatePinFailure(INVALID_NUMBER);
     }
 
-    private void validatePinSuccess(String phoneNumber) {
-    	
+    private void validatePinSuccess(String phoneNumber) {    	
         SerenityRest.given().relaxedHTTPSValidation()
                 .headers(utils.getHeaders(SESSION_ID))
                 .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
@@ -39,7 +38,6 @@ public class BusinessServicePinControllerTests extends IntegrationTestBase {
                 .headers(utils.getHeaders(SESSION_ID))
                 .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
                 .thenReturn();
-
         response.then().assertThat().statusCode(500)
                 .and().body("error", equalTo("Internal Server Error"))
                 .and().body("message", containsString("Status code: 400"));

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -16,6 +16,7 @@ import uk.gov.service.notify.NotificationClientException;
 public class PinController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PinController.class);
+    
     @Autowired
     private PinService pinService;
 
@@ -23,12 +24,17 @@ public class PinController {
     public ResponseEntity<String> invite(@RequestParam String phoneNumber,
                          @RequestHeader("Session-Id") String sessionId) throws NotificationClientException, UnsupportedEncodingException {
  	
+		if ( null == sessionId ) {
+			LOGGER.error("Session-Id request header not found");
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+		}
+    	LOGGER.info("Processing session id " + sessionId);
+    	
 		phoneNumber = URLDecoder.decode(phoneNumber, java.nio.charset.StandardCharsets.UTF_8.toString());
-		
-		phoneNumber = phoneNumber.replaceAll("[ \\(\\)\\[\\]-]", "");		
+		phoneNumber = phoneNumber.replaceAll("[ \\(\\)\\[\\]-]", "");			
 		
 		if ( !phoneNumber.matches("(\\+)*[0-9]+") ) {
-			LOGGER.error("Unable to validate phoneNumber");
+			LOGGER.error("Unable to validate phoneNumber parameter");
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 		}
 		

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -2,13 +2,20 @@ package uk.gov.hmcts.probate.services.pin.controllers;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import uk.gov.hmcts.probate.services.pin.PinService;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -16,6 +23,8 @@ import uk.gov.service.notify.NotificationClientException;
 public class PinController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PinController.class);
+    private static final String VALID_PHONENUMBER_CHARACTERS_REGEX = "(\\+)*[0-9]+";
+    private static final String INVALID_PHONENUMBER_CHARACTERS_REGEX = "[ \\(\\)\\[\\]-]";
     
     @Autowired
     private PinService pinService;
@@ -23,28 +32,23 @@ public class PinController {
     @RequestMapping(path = "/pin", method = RequestMethod.GET)
     public ResponseEntity<String> invite(@RequestParam String phoneNumber,
                          @RequestHeader("Session-Id") String sessionId) throws NotificationClientException, UnsupportedEncodingException {
- 	
-		if ( null == sessionId ) {
+		if (sessionId == null) {
 			LOGGER.error("Session-Id request header not found");
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 		}
     	LOGGER.info("Processing session id " + sessionId);
-    	
-		phoneNumber = URLDecoder.decode(phoneNumber, java.nio.charset.StandardCharsets.UTF_8.toString());
-		phoneNumber = phoneNumber.replaceAll("[ \\(\\)\\[\\]-]", "");			
-		
-		if ( !phoneNumber.matches("(\\+)*[0-9]+") ) {
+		phoneNumber = URLDecoder.decode(phoneNumber, StandardCharsets.UTF_8.toString());
+		phoneNumber = phoneNumber.replaceAll(INVALID_PHONENUMBER_CHARACTERS_REGEX, "");			
+		if (!phoneNumber.matches(VALID_PHONENUMBER_CHARACTERS_REGEX)) {
 			LOGGER.error("Unable to validate phoneNumber parameter");
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 		}
-		
 		return ResponseEntity.ok(pinService.generateAndSend(phoneNumber));
     }
 
     @RequestMapping(path = "/pin/{phoneNumber}", method = RequestMethod.GET)
     public String inviteLegacy(@PathVariable String phoneNumber,
-                           @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {
-	     
+                           @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {     
 	    LOGGER.info("Processing session id " + sessionId);
         return pinService.generateAndSend(phoneNumber);
     }

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.probate.services.pin.controllers;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.probate.services.pin.PinService;
 import uk.gov.service.notify.NotificationClientException;
@@ -14,12 +19,28 @@ public class PinController {
     @Autowired
     private PinService pinService;
 
+    @RequestMapping(path = "/pin", method = RequestMethod.GET)
+    public ResponseEntity<String> invite(@RequestParam String phoneNumber,
+                         @RequestHeader("Session-Id") String sessionId) throws NotificationClientException, UnsupportedEncodingException {
+ 	
+		phoneNumber = URLDecoder.decode(phoneNumber, java.nio.charset.StandardCharsets.UTF_8.toString());
+		
+		phoneNumber = phoneNumber.replaceAll("[ \\(\\)\\[\\]-]", "");		
+		
+		if ( !phoneNumber.matches("(\\+)*[0-9]+") ) {
+			LOGGER.error("Unable to validate phoneNumber");
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+		}
+		
+		return ResponseEntity.ok(pinService.generateAndSend(phoneNumber));
+    }
+
     @RequestMapping(path = "/pin/{phoneNumber}", method = RequestMethod.GET)
-    public String invite(@PathVariable String phoneNumber,
-                         @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {
-
-        LOGGER.info("Processing session id " + sessionId);
-
+    public String inviteLegacy(@PathVariable String phoneNumber,
+                           @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {
+	     
+	    LOGGER.info("Processing session id " + sessionId);
         return pinService.generateAndSend(phoneNumber);
     }
+    
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -28,7 +28,10 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 public class PinControllerTest {
 
     private static final String SERVICE_URL = "/pin";
-    private static final String TEST_PHONE_NUMBER = "07700900111";
+    private static final String TEST_SESSION_ID = "1234567890";
+    private static final String TEST_UK_PHONE_NUMBER = "(0)7700900111";
+    private static final String TEST_INT_PHONE_NUMBER = "%2B447700900111";
+    private static final String TEST_BAD_PHONE_NUMBER = "$447700900111"; 
 
     private MediaType contentType = new MediaType(MediaType.TEXT_PLAIN.getType(),
             MediaType.TEXT_PLAIN.getSubtype(),
@@ -58,11 +61,39 @@ public class PinControllerTest {
     }
 
     @Test
-    public void generatePin() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(SERVICE_URL + "/" + TEST_PHONE_NUMBER)
-                .header("Session-Id", "1234567890")
+    public void generatePinFromUkNumber() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
                 .contentType(contentType))
                 .andExpect(status().isOk())
                 .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
+    @Test
+    public void generatePinFromInternationalNumber() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_INT_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+    @Test
+    public void generatePinFromBadNumber() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_BAD_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void generatePinFromBadParameterName() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?number=" + TEST_UK_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void generatePinFromMissingSessionId() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
+                .contentType(contentType))
+                .andExpect(status().isBadRequest());
+    }    
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.probate.services.businessvalidation.util.TestUtils;
 
@@ -48,7 +47,6 @@ public class PinControllerTest {
 
     @Autowired
     void setConverters(HttpMessageConverter<?>[] converters) {
-
         Arrays.stream(converters)
                 .filter(hmc -> hmc instanceof MappingJackson2HttpMessageConverter)
                 .findFirst()
@@ -62,7 +60,7 @@ public class PinControllerTest {
 
     @Test
     public void generatePinFromUkNumber() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
+        mockMvc.perform(get(SERVICE_URL+"?phoneNumber="+TEST_UK_PHONE_NUMBER)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(contentType))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
-import uk.gov.hmcts.probate.services.businessvalidation.util.TestUtils;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -37,10 +36,8 @@ public class PinControllerTest {
             Charset.forName("utf8"));
 
     private MockMvc mockMvc;
-    private HttpMessageConverter mappingJackson2HttpMessageConverter;
-
-    @Autowired
-    private TestUtils utils;
+    @SuppressWarnings("unused")
+	private HttpMessageConverter<?> mappingJackson2HttpMessageConverter;
 
     @Autowired
     private WebApplicationContext webApplicationContext;

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -30,6 +30,7 @@ public class PinControllerTest {
     private static final String TEST_UK_PHONE_NUMBER = "(0)7700900111";
     private static final String TEST_INT_PHONE_NUMBER = "%2B447700900111";
     private static final String TEST_BAD_PHONE_NUMBER = "$447700900111"; 
+    private static final String TEST_LARGE_PHONE_NUMBER = "%2B10900111000111000111";
 
     private MediaType contentType = new MediaType(MediaType.TEXT_PLAIN.getType(),
             MediaType.TEXT_PLAIN.getSubtype(),
@@ -66,6 +67,14 @@ public class PinControllerTest {
     @Test
     public void generatePinFromInternationalNumber() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_INT_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+    @Test
+    public void generatePinFromLargeInternationalNumber() throws Exception {
+        mockMvc.perform(get(SERVICE_URL+"?phoneNumber="+TEST_LARGE_PHONE_NUMBER)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(contentType))
                 .andExpect(status().isOk())


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3459

### Change description ###
PinController.java has been updated to change the generate pin endpoint for invites.
Exsiting invite endpoint /pin/{phoneNumber}
New invite endpoint /pin?phoneNumber={URLEncodedPhoneNumber} 

This change was required to address the issues with international numbers not appearing in the Business Service logs which was resulting in the DebugConsole showing 404 messages for anything with a '+' included in the number. With no reference in the logs, then there was no subsiquient call to send the SMS message.

This change affects the Probate PA Frontend application as well, so the existing endpoint for now /pin/{phoneNumber} has been retained to allow the frontend application to continue until the PRO-3459 branch is merged for the frontend application.

It should be noted that although this has been tested in development, the build process while successful for Checkout, Build, Test, Security Checks, Sonar Scan has suddently stopped - I'm assuming this is because of the ongoing environment issues in Azure.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
