### PR TITLE
PRO-5691: Link to probate page on gov uk website in footer of declara…

### DIFF
--- a/src/main/resources/templates/pdf/legalDeclaration.html
+++ b/src/main/resources/templates/pdf/legalDeclaration.html
@@ -130,10 +130,10 @@
 <div class="footer" id="pageFooter">
     <div class="line">&#160;</div>
   {% if bilingual == false %}
-    <p class="alignleft">For further details on probate visit www.gov.uk/probate</p>
+    <p class="alignleft">For further details on probate visit www.gov.uk/applying-for-probate</p>
     <p class="alignright">&#0169; Crown copyright, Page <span id="pagenumber"></span> of <span id="pagecount"></span></p>
   {% else %}
-    <p class="alignleft">Am ragor o wybodaeth am Brofiant, ewch i www.gov.uk/probate</p>
+    <p class="alignleft">Am ragor o wybodaeth am Brofiant, ewch i www.gov.uk/applying-for-probate</p>
     <p class="alignright">&#0169; Hawlfraint y Goron, Tudalen <span id="pagenumber"></span> o <span id="pagecount"></span></p>
   {% endif %}
     <p class="alignleft">Downloaded on: {{dateCreated}}</p>


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5691

### Change description ###

Link to probate page on gov uk website in footer of declaration pdf is invalid

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
