### PR TITLE
DTSPB-4664 Convert GETs to POSTs so we do not log parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ def versions = [
         logging          : '6.1.8',
         lombok           : '1.18.38',
         pact_version     : '4.1.11',
-        probateCommons   : '2.0.56',
+        probateCommons   : '2.1.0',
         restAssured      : '5.5.1',
         serenity         : '4.2.22',
         serenityreporter : '4.1.6',

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
@@ -23,70 +23,112 @@ public class BusinessServicePinControllerTests extends IntegrationTestBase {
         validatePinFailure(INVALID_NUMBER);
     }
 
+    private String getPinBody(final String phoneNumber) {
+        return String.format(
+            """
+            {
+                "PhonePin": {
+                    "phoneNumber": "%s"
+                }
+            }
+            """,
+            phoneNumber);
+    }
+
     private void validatePinSuccess(String phoneNumber) {
+        final String body = getPinBody(phoneNumber);
+
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
-            .then().assertThat().statusCode(200);
+            .body(body)
+            .when()
+            .post(businessServiceUrl + "/pin")
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(200);
     }
 
     private void validatePinFailure(String phoneNumber) {
+        final String body = getPinBody(phoneNumber);
+
         Response response = given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin?phoneNumber=" + phoneNumber)
+            .body(body)
+            .when().post(businessServiceUrl + "/pin")
             .thenReturn();
-        response.then().assertThat().statusCode(400);
+        response.then().log().ifValidationFails()
+            .assertThat().statusCode(400);
     }
 
     @Test
     public void testValidatePinFailurePhoneNumberWithNoEnoughDigits() {
-        given().relaxedHTTPSValidation()
-            .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin?phoneNumber=" + 34)
-            .then().assertThat().statusCode(500)
-            .extract().response().prettyPrint();
-    }
+        final String body = getPinBody("34");
 
-    @Test
-    public void testInviteWithPhoneNumber() {
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin/" + mobileNumber)
-            .then().assertThat().statusCode(200);
-    }
-
-    @Test
-    public void testInviteWithInvaidPhoneNumber() {
-        given().relaxedHTTPSValidation()
-            .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin/" + INVALID_NUMBER)
-            .then().assertThat().statusCode(500)
-            .extract().response().prettyPrint();
+            .body(body)
+            .when().post(businessServiceUrl + "/pin")
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(500);
     }
 
     @Test
     public void testInvitebilingual() {
+        final String body = getPinBody(mobileNumber);
+
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin/bilingual?phoneNumber=" + mobileNumber)
-            .then().assertThat().statusCode(200);
+            .body(body)
+            .when().post(businessServiceUrl + "/pin/bilingual")
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(200);
     }
 
     @Test
     public void testInvitebilingualWithInvalidPhoneNumber() {
+        final String body = getPinBody(INVALID_NUMBER);
+
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin/bilingual?phoneNumber=" + INVALID_NUMBER)
-            .then().assertThat().statusCode(400);
+            .body(body)
+            .when().post(businessServiceUrl + "/pin/bilingual")
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(400);
     }
 
     @Test
     public void testInviteBilingualPhoneNumberWithNoEnoughDigits() {
+        final String body = getPinBody("34");
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
-            .when().get(businessServiceUrl + "/pin/bilingual?phoneNumber=" + 34)
-            .then().assertThat().statusCode(500)
-            .extract().response().prettyPrint();
+            .body(body)
+            .when().post(businessServiceUrl + "/pin/bilingual")
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(500);
+    }
+
+    @Test void testInviteGetWithParamFails() {
+        given().relaxedHTTPSValidation()
+            .headers(utils.getHeaders(SESSION_ID))
+            .when().get(businessServiceUrl + "/pin?phoneNumber=" + mobileNumber)
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(405);
+    }
+
+    @Test void testBilingualInviteGetWithParamFails() {
+        given().relaxedHTTPSValidation()
+            .headers(utils.getHeaders(SESSION_ID))
+            .when().get(businessServiceUrl + "/pin/bilingual?phoneNumber=" + mobileNumber)
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(405);
+    }
+
+    @Test
+    public void testInviteGetWithUrlFails() {
+        given().relaxedHTTPSValidation()
+            .headers(utils.getHeaders(SESSION_ID))
+            .when().get(businessServiceUrl + "/pin/" + mobileNumber)
+            .then().log().ifValidationFails()
+            .assertThat().statusCode(404);
     }
 
 

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/BusinessServicePinControllerTests.java
@@ -106,29 +106,29 @@ public class BusinessServicePinControllerTests extends IntegrationTestBase {
             .assertThat().statusCode(500);
     }
 
-    @Test void testInviteGetWithParamFails() {
+    @Test void testInviteGetWithParamSucceeds() {
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
             .when().get(businessServiceUrl + "/pin?phoneNumber=" + mobileNumber)
             .then().log().ifValidationFails()
-            .assertThat().statusCode(405);
+            .assertThat().statusCode(200);
     }
 
-    @Test void testBilingualInviteGetWithParamFails() {
+    @Test void testBilingualInviteGetWithParamSucceeds() {
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
             .when().get(businessServiceUrl + "/pin/bilingual?phoneNumber=" + mobileNumber)
             .then().log().ifValidationFails()
-            .assertThat().statusCode(405);
+            .assertThat().statusCode(200);
     }
 
     @Test
-    public void testInviteGetWithUrlFails() {
+    public void testInviteGetWithUrlSucceeds() {
         given().relaxedHTTPSValidation()
             .headers(utils.getHeaders(SESSION_ID))
             .when().get(businessServiceUrl + "/pin/" + mobileNumber)
             .then().log().ifValidationFails()
-            .assertThat().statusCode(404);
+            .assertThat().statusCode(200);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/probate/handlers/PinExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/handlers/PinExceptionHandler.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.probate.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import uk.gov.hmcts.probate.services.businessdocuments.model.ErrorResponse;
+import uk.gov.hmcts.probate.services.pin.exceptions.PhonePinException;
+
+@Slf4j
+@ControllerAdvice
+@ResponseBody
+public class PinExceptionHandler {
+    public static final String PHONE_PIN_EXCEPTION = "PhonePin Error";
+
+    @ExceptionHandler(PhonePinException.class)
+    public ResponseEntity<ErrorResponse> handle(PhonePinException exception) {
+        log.warn("PhonePin exception: {}", exception.getMessage(), exception);
+
+        ErrorResponse errorResponse =
+            new ErrorResponse(HttpStatus.BAD_REQUEST.value(), PHONE_PIN_EXCEPTION, exception.getMessage());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(errorResponse, headers, HttpStatus.valueOf(errorResponse.getCode()));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -50,20 +50,6 @@ public class PinController {
         return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.TRUE);
     }
 
-    @RequestMapping(path = "/pin", method = RequestMethod.GET)
-    public ResponseEntity<String> invite(@RequestParam String phoneNumber,
-                                         @RequestHeader("Session-Id") String sessionId)
-        throws NotificationClientException, UnsupportedEncodingException {
-        return getStringResponseEntity(phoneNumber, sessionId, Boolean.FALSE);
-    }
-
-    @RequestMapping(path = "/pin/bilingual", method = RequestMethod.GET)
-    public ResponseEntity<String> inviteBilingual(@RequestParam String phoneNumber,
-                                                  @RequestHeader("Session-Id") String sessionId)
-        throws NotificationClientException, UnsupportedEncodingException {
-        return getStringResponseEntity(phoneNumber, sessionId, Boolean.TRUE);
-    }
-
     private ResponseEntity<String> getStringResponseEntity(String phoneNumber, String sessionId, Boolean isBilingual)
         throws UnsupportedEncodingException, NotificationClientException {
         if (sessionId == null) {
@@ -78,13 +64,6 @@ public class PinController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
         return ResponseEntity.ok(pinService.generateAndSend(phoneNumber, isBilingual));
-    }
-
-    @RequestMapping(path = "/pin/{phoneNumber}", method = RequestMethod.GET)
-    public String inviteLegacy(@PathVariable String phoneNumber,
-                               @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {
-        LOGGER.info("Processing session id " + sessionId);
-        return pinService.generateAndSend(phoneNumber, Boolean.FALSE);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -7,12 +7,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.services.pin.PinService;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.io.UnsupportedEncodingException;
@@ -29,6 +31,24 @@ public class PinController {
 
     @Autowired
     private PinService pinService;
+
+    @RequestMapping(path = "/pin", method = RequestMethod.POST)
+    public ResponseEntity<String> invitePost(
+            @RequestHeader("Session-Id") final String sessionId,
+            @RequestBody final PhonePin phonePin)
+            throws NotificationClientException, UnsupportedEncodingException {
+        return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.FALSE);
+    }
+
+    @RequestMapping(path = "/pin/bilingual", method = RequestMethod.POST)
+    public ResponseEntity<String> inviteBilingualPost(
+        @RequestHeader("Session-Id") final String sessionId,
+        @RequestBody final PhonePin phonePin
+    )
+        throws NotificationClientException, UnsupportedEncodingException {
+
+        return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.TRUE);
+    }
 
     @RequestMapping(path = "/pin", method = RequestMethod.GET)
     public ResponseEntity<String> invite(@RequestParam String phoneNumber,

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -8,9 +8,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.services.pin.PinService;
 import uk.gov.hmcts.probate.services.pin.exceptions.PhonePinException;
@@ -32,6 +36,17 @@ public class PinController {
     @Autowired
     private PinService pinService;
 
+    //
+    // The below should be removed ASAP but need to exist to provide a bridge during deployment
+    //
+    @RequestMapping(path = "/pin", method = RequestMethod.GET)
+    public ResponseEntity<String> invite(@RequestParam String phoneNumber,
+                                         @RequestHeader("Session-Id") String sessionId)
+        throws NotificationClientException, UnsupportedEncodingException {
+        LOGGER.warn("using unsafe GET for /pin");
+        return getStringResponseEntity(phoneNumber, sessionId, Boolean.FALSE);
+    }
+
     @PostMapping(path = "/pin")
     public ResponseEntity<String> invitePost(
             @RequestHeader("Session-Id") final String sessionId,
@@ -42,6 +57,17 @@ public class PinController {
             throw new PhonePinException("PhonePin invalid");
         }
         return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.FALSE);
+    }
+
+    //
+    // The below should be removed ASAP but need to exist to provide a bridge during deployment
+    //
+    @RequestMapping(path = "/pin/bilingual", method = RequestMethod.GET)
+    public ResponseEntity<String> inviteBilingual(@RequestParam String phoneNumber,
+                                                  @RequestHeader("Session-Id") String sessionId)
+        throws NotificationClientException, UnsupportedEncodingException {
+        LOGGER.warn("using unsafe GET for /pin/bilingual");
+        return getStringResponseEntity(phoneNumber, sessionId, Boolean.TRUE);
     }
 
     @PostMapping(path = "/pin/bilingual")
@@ -70,6 +96,17 @@ public class PinController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
         return ResponseEntity.ok(pinService.generateAndSend(phoneNumber, isBilingual));
+    }
+
+    //
+    // The below should be removed ASAP but need to exist to provide a bridge during deployment
+    //
+    @RequestMapping(path = "/pin/{phoneNumber}", method = RequestMethod.GET)
+    public String inviteLegacy(@PathVariable String phoneNumber,
+                               @RequestHeader("Session-Id") String sessionId) throws NotificationClientException {
+        LOGGER.warn("using unsafe GET for /pin/{phoneNumber}");
+        LOGGER.info("Processing session id " + sessionId);
+        return pinService.generateAndSend(phoneNumber, Boolean.FALSE);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -1,19 +1,20 @@
 package uk.gov.hmcts.probate.services.pin.controllers;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.services.pin.PinService;
+import uk.gov.hmcts.probate.services.pin.exceptions.PhonePinException;
 import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -35,18 +36,24 @@ public class PinController {
     @RequestMapping(path = "/pin", method = RequestMethod.POST)
     public ResponseEntity<String> invitePost(
             @RequestHeader("Session-Id") final String sessionId,
-            @RequestBody final PhonePin phonePin)
+            @Valid @RequestBody final PhonePin phonePin,
+            BindingResult bindingResult)
             throws NotificationClientException, UnsupportedEncodingException {
+        if (bindingResult.hasErrors()) {
+            throw new PhonePinException("PhonePin invalid");
+        }
         return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.FALSE);
     }
 
     @RequestMapping(path = "/pin/bilingual", method = RequestMethod.POST)
     public ResponseEntity<String> inviteBilingualPost(
         @RequestHeader("Session-Id") final String sessionId,
-        @RequestBody final PhonePin phonePin
-    )
+        @Valid @RequestBody final PhonePin phonePin,
+        BindingResult bindingResult)
         throws NotificationClientException, UnsupportedEncodingException {
-
+        if (bindingResult.hasErrors()) {
+            throw new PhonePinException("PhonePin invalid");
+        }
         return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.TRUE);
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/controllers/PinController.java
@@ -8,10 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.services.pin.PinService;
 import uk.gov.hmcts.probate.services.pin.exceptions.PhonePinException;
@@ -33,7 +32,7 @@ public class PinController {
     @Autowired
     private PinService pinService;
 
-    @RequestMapping(path = "/pin", method = RequestMethod.POST)
+    @PostMapping(path = "/pin")
     public ResponseEntity<String> invitePost(
             @RequestHeader("Session-Id") final String sessionId,
             @Valid @RequestBody final PhonePin phonePin,
@@ -45,7 +44,7 @@ public class PinController {
         return getStringResponseEntity(phonePin.getPhoneNumber(), sessionId, Boolean.FALSE);
     }
 
-    @RequestMapping(path = "/pin/bilingual", method = RequestMethod.POST)
+    @PostMapping(path = "/pin/bilingual")
     public ResponseEntity<String> inviteBilingualPost(
         @RequestHeader("Session-Id") final String sessionId,
         @Valid @RequestBody final PhonePin phonePin,

--- a/src/main/java/uk/gov/hmcts/probate/services/pin/exceptions/PhonePinException.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/pin/exceptions/PhonePinException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.probate.services.pin.exceptions;
+
+public class PhonePinException extends RuntimeException {
+    public PhonePinException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -18,7 +18,6 @@ import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendSmsResponse;
 
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -42,11 +41,6 @@ class PinControllerTest {
     private static final String TEST_BAD_PHONE_NUMBER = "$447700900111";
     private static final String TEST_LARGE_PHONE_NUMBER = "%2B109001110001110";
     private SendSmsResponse smsResponse;
-
-
-    private MediaType contentType = new MediaType(MediaType.TEXT_PLAIN.getType(),
-        MediaType.TEXT_PLAIN.getSubtype(),
-        Charset.forName("utf8"));
 
     private MockMvc mockMvc;
     @SuppressWarnings("unused")

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
@@ -82,10 +83,30 @@ class PinControllerTest {
     }
 
     @Test
+    void generatePinFromUkNumberPost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @Test
     void generatePinFromInternationalNumber() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_INT_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @Test
+    void generatePinFromInternationalNumberPost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
             .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_INT_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
@@ -93,8 +114,18 @@ class PinControllerTest {
     @Test
     void generatePinFromLargeInternationalNumber() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_LARGE_PHONE_NUMBER)
-            .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @Test
+    void generatePinFromLargeInternationalNumberPost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_LARGE_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
@@ -102,8 +133,18 @@ class PinControllerTest {
     @Test
     void generatePinFromBadNumber() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_BAD_PHONE_NUMBER)
-            .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @Test
+    void generatePinFromBadNumberPost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_BAD_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
@@ -111,15 +152,32 @@ class PinControllerTest {
     @Test
     void generatePinFromBadParameterName() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?number=" + TEST_UK_PHONE_NUMBER)
-            .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(contentType))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void generatePinFromBadParameterNamePost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"number\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isBadRequest());
     }
 
     @Test
     void generatePinFromMissingSessionId() throws Exception {
         mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
-            .contentType(contentType))
+                .contentType(contentType))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void generatePinFromMissingSessionIdPost() throws Exception {
+        mockMvc.perform(post(SERVICE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isBadRequest());
     }
 
@@ -142,6 +200,18 @@ class PinControllerTest {
         mockMvc.perform(get(BILINGUAL_URL + "?phoneNumber=" + phoneNumber)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(contentType))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("phoneNumber")
+    void inviteBilingualPost(final String phoneNumber) throws Exception {
+        mockMvc.perform(post(BILINGUAL_URL)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + phoneNumber + "\"}}")
+            )
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -74,29 +73,11 @@ class PinControllerTest {
     }
 
     @Test
-    void generatePinFromUkNumber() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
-            .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
-    }
-
-    @Test
     void generatePinFromUkNumberPost() throws Exception {
         mockMvc.perform(post(SERVICE_URL)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
-    }
-
-    @Test
-    void generatePinFromInternationalNumber() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_INT_PHONE_NUMBER)
-                .header("Session-Id", TEST_SESSION_ID)
-                .contentType(contentType))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
@@ -112,29 +93,11 @@ class PinControllerTest {
     }
 
     @Test
-    void generatePinFromLargeInternationalNumber() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_LARGE_PHONE_NUMBER)
-                .header("Session-Id", TEST_SESSION_ID)
-                .contentType(contentType))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
-    }
-
-    @Test
     void generatePinFromLargeInternationalNumberPost() throws Exception {
         mockMvc.perform(post(SERVICE_URL)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_LARGE_PHONE_NUMBER + "\"}}"))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
-    }
-
-    @Test
-    void generatePinFromBadNumber() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_BAD_PHONE_NUMBER)
-                .header("Session-Id", TEST_SESSION_ID)
-                .contentType(contentType))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
@@ -150,26 +113,11 @@ class PinControllerTest {
     }
 
     @Test
-    void generatePinFromBadParameterName() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?number=" + TEST_UK_PHONE_NUMBER)
-                .header("Session-Id", TEST_SESSION_ID)
-                .contentType(contentType))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
     void generatePinFromBadParameterNamePost() throws Exception {
         mockMvc.perform(post(SERVICE_URL)
                 .header("Session-Id", TEST_SESSION_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"PhonePin\": {\"number\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void generatePinFromMissingSessionId() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
-                .contentType(contentType))
             .andExpect(status().isBadRequest());
     }
 
@@ -181,27 +129,8 @@ class PinControllerTest {
             .andExpect(status().isBadRequest());
     }
 
-    @Test
-    void inviteLegacy() throws Exception {
-        mockMvc.perform(get(SERVICE_URL + "/" + TEST_UK_PHONE_NUMBER)
-            .header("Session-Id", TEST_SESSION_ID)
-            .contentType(contentType))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
-    }
-
     private static Stream<String> phoneNumber() {
         return Stream.of(TEST_UK_PHONE_NUMBER, TEST_INT_PHONE_NUMBER, TEST_LARGE_PHONE_NUMBER);
-    }
-
-    @ParameterizedTest
-    @MethodSource("phoneNumber")
-    void inviteBilingual(final String phoneNumber) throws Exception {
-        mockMvc.perform(get(BILINGUAL_URL + "?phoneNumber=" + phoneNumber)
-                .header("Session-Id", TEST_SESSION_ID)
-                .contentType(contentType))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lessThanOrEqualTo("999999")));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/pin/integration/PinControllerTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -135,6 +136,42 @@ class PinControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"PhonePin\": {\"phoneNumber\": \"" + phoneNumber + "\"}}")
             )
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    //
+    // these will be removed when the controller methods are
+    //
+
+    @Test
+    void generatePinFromUkNumberGet() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "?phoneNumber=" + TEST_UK_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("phoneNumber")
+    void inviteBilingualGet(final String phoneNumber) throws Exception {
+        mockMvc.perform(get(BILINGUAL_URL + "?phoneNumber=" + phoneNumber)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + phoneNumber + "\"}}")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().string(lessThanOrEqualTo("999999")));
+    }
+
+    @Test
+    void generatePinFromLegacyGet() throws Exception {
+        mockMvc.perform(get(SERVICE_URL + "/" + TEST_UK_PHONE_NUMBER)
+                .header("Session-Id", TEST_SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"PhonePin\": {\"phoneNumber\": \"" + TEST_UK_PHONE_NUMBER + "\"}}"))
             .andExpect(status().isOk())
             .andExpect(content().string(lessThanOrEqualTo("999999")));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4664](https://tools.hmcts.net/jira/browse/DTSPB-4664)


### Change description ###
Uses new model provided in https://github.com/hmcts/probate-commons/pull/256 as the body of POSTs. This stops the current behaviour where parameters are logged.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
