### PR TITLE
DTSPB-5643 Bump HMCTS Java to 0.12.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.springframework.boot' version '3.5.14'
-    id 'uk.gov.hmcts.java' version '0.12.68'
+    id 'uk.gov.hmcts.java' version '0.12.70'
     id 'com.github.ben-manes.versions' version '0.54.0'
     id 'com.gorylenko.gradle-git-properties' version '3.0.3'
     id 'info.solidsoft.pitest' version '1.19.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,4 +35,22 @@
   <suppress until = "2026-07-13">
     <cve>CVE-2025-21199</cve>
   </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41842</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41850</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41851</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41840</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41841</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2026-41843</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,4 +24,15 @@
       -->
       <cve>CVE-2025-15104</cve>
     </suppress>
+  <suppress until = "2026-07-13">
+    <!--
+       The scanner is doing a version-range match on the CVE's CPE, and your tool is matching the fasterxml:jackson-core:3.0.1 CPE
+       broadly across both your 3.x JARs and your 2.x JARs. NVD uses CPEs that apply to a range of versions, which requires its own
+       version comparison logic — and this is commonly a source of false positives when version schemes change or when a product changes its namespace.
+    -->
+    <cve>CVE-2026-29062</cve>
+  </suppress>
+  <suppress until = "2026-07-13">
+    <cve>CVE-2025-21199</cve>
+  </suppress>
 </suppressions>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,3 @@
 [versions]
 commonsLang3 = "3.20.0"
-log4j2 = "2.25.3"
+log4j2 = "2.26.0"


### PR DESCRIPTION


### JIRA link (if applicable) ###

[DTSPB-5643](https://tools.hmcts.net/jira/browse/DTSPB-5643)

### Change description ###

DTSPB-5643 Bump HMCTS Java to 0.12.70

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
