### PR TITLE
DTSPB-5808 bump httpcore5 and httpcore5-h2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,12 @@ dependencyManagement {
   imports {
     mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2025.0.0'
   }
+  dependencies {
+    dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
+      entry 'httpcore5'
+      entry 'httpcore5-h2'
+    }
+  }
 }
 
 ext {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -66,4 +66,11 @@
     <cve>CVE-2026-54517</cve>
     <cve>CVE-2026-54518</cve>
   </suppress>
+  <suppress until = "2026-10-13">
+    <notes><![CDATA[
+   file name: httpcore-4.4.16.jar
+   ]]></notes>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPB-5808


### Change description ###
bump httpcore5 and httpcore5-h2
suppress transitive CVE for httpcore-4.4.16

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
